### PR TITLE
Push errors with a message and field name

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -96,7 +96,7 @@ function form() {
         map[name] = map[name] || [];
       
         result.forEach(function (error) {
-          errors.push(error);
+          errors.push({field:name, message:error});
           map[name].push(error);
         });
         


### PR DESCRIPTION
This change will provide more info in errors array. The final array will look like:

```
[
    {
      "field": "id",
      "message": "id is not an integer"
    },
    {
      "field": "name",
      "message": "name is required"
    }
]
```
