### PR TITLE
make current async version compulsory

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "validator": "0.4.x",
     "object-additions": ">= 0.5.0",
-    "async": "~0.2.9"
+    "async": "0.2.9"
   },
   "peerDependencies": {
     "express": "3.x"


### PR DESCRIPTION
I've been having intermittent problems with my code, giving the error message `TypeError: Object #<Object> has no method 'each'`. I've traced the problem to `express-form`, specifically when the version of the `async` requirment which gets installed is `async@0.1.0`. The problem isn't visible when the version which gets installed is `async@0.2.9`.

The existing `~` in the `async` dependency in `package.json` lets the earlier version of the package be installed.

For reference:

```
$ npm --version
1.3.0
$ node --version
v0.8.25
```
