### PR TITLE
Remove upper bound on TLD length for email validation

### DIFF
--- a/lib/field.js
+++ b/lib/field.js
@@ -312,7 +312,7 @@ Field.prototype.isFloat = Field.prototype.isDecimal = function (message) {
 // super simple email validation
 Field.prototype.isEmail = function (message) {
   return this.add(function (value) {
-    if (typeof value != 'string' || !(/^[\-0-9a-zA-Z\.\+_]+@[\-0-9a-zA-Z\.\+_]+\.[a-zA-Z]{2,4}$/).test(value)) {
+    if (typeof value != 'string' || !(/^[\-0-9a-zA-Z\.\+_]+@[\-0-9a-zA-Z\.\+_]+\.[a-zA-Z]{2,}$/).test(value)) {
       return { error: message || "%s is not an email address" };
     }
     return { valid: true };

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -56,7 +56,8 @@ module.exports = {
       "user@host.co.uk",
       "user+service@host.co.uk",
       "user-ok.yes+tag@host.k12.mi.us",
-      "FirstNameLastName2000@hotmail.com"
+      "FirstNameLastName2000@hotmail.com",
+      "FooBarEmail@foo.apartments"
     ];
 
     for (var i in validEmails) {


### PR DESCRIPTION
This change introduces support for [longer, generic TLDs][1] in `isEmail` validator. Currently, an email such as "fooBar@myco.media" fails.

[1]: https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains#ICANN-era_generic_top-level_domains