### PR TITLE
Guard against request body's not inheriting from Object.prototype

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -27,7 +27,7 @@ function form() {
     
     if (options.autoLocals) {
       for (var prop in req.body) {
-        if (!req.body.hasOwnProperty(prop)) continue;
+        if (!Object.hasOwnProperty.call(req.body, prop)) continue;
         
         /*
          * express 1.x and 3.x


### PR DESCRIPTION
I'm not sure if it was upgrading Node (to version 6.0.0) or Express (to vesion 4.13.3), but all of a sudden I started getting `TypeError: req.body.hasOwnProperty is not a function` errors.

This patched fixed the problem.